### PR TITLE
I've fixed the database error that occurred when an admin updates a u…

### DIFF
--- a/server.js
+++ b/server.js
@@ -259,9 +259,10 @@ app.put('/api/admin/users/:id', authenticateToken, requireAdmin, async (req, res
     let updateFields = [];
     let queryParams = [];
 
-    if (first_name) {
+    // Use `!== undefined` to allow clearing the field by sending an empty string
+    if (first_name !== undefined) {
         updateFields.push('first_name = ?');
-        queryParams.push(first_name);
+        queryParams.push(first_name || null); // Use null if string is empty
     }
     if (email) {
         updateFields.push('email = ?');
@@ -276,22 +277,22 @@ app.put('/api/admin/users/:id', authenticateToken, requireAdmin, async (req, res
         updateFields.push('password = ?');
         queryParams.push(hashedPassword);
     }
-    // Allow setting vehicle info to null/empty
+    // Allow setting vehicle info to null/empty by converting empty strings to null
     if (current_vehicle_make !== undefined) {
         updateFields.push('current_vehicle_make = ?');
-        queryParams.push(current_vehicle_make);
+        queryParams.push(current_vehicle_make || null);
     }
     if (current_vehicle_model !== undefined) {
         updateFields.push('current_vehicle_model = ?');
-        queryParams.push(current_vehicle_model);
+        queryParams.push(current_vehicle_model || null);
     }
     if (current_vehicle_year !== undefined) {
         updateFields.push('current_vehicle_year = ?');
-        queryParams.push(current_vehicle_year);
+        queryParams.push(current_vehicle_year || null);
     }
     if (current_vehicle_color !== undefined) {
         updateFields.push('current_vehicle_color = ?');
-        queryParams.push(current_vehicle_color);
+        queryParams.push(current_vehicle_color || null);
     }
     if (bio !== undefined) {
         const bioJSON = bio ? JSON.stringify(bio) : null;


### PR DESCRIPTION
…ser with empty fields.

The issue was that when an admin user saved changes to a user's profile with some fields left blank (e.g., vehicle information), the server would receive empty strings for these fields. The server was attempting to write these empty strings to the database for columns that expect NULL for empty values, which resulted in a 'Database error while updating user.' message.

I fixed this by modifying the `PUT /api/admin/users/:id` endpoint in `server.js`. I updated the logic to convert any empty string values for `first_name` and all `current_vehicle_*` fields to `NULL` before performing the database update.

This change also fixes a related bug where an admin could not clear a user's first name, as the update logic was previously skipping fields with empty string values.