### PR TITLE
feat: Implement comprehensive vehicle type badge system

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,6 +27,39 @@ const db = mysql.createPool({
 // Vehicle data required for badge logic
 const vehicleSubtype = {"Acura":{"ILX":"Sedan","Integra":"Sedan","MDX":"SUV","NSX":"Sports Car","RDX":"SUV","RL":"Sedan","RLX":"Sedan","TLX":"Sedan","ZDX":"SUV"},"Alfa Romeo":{"Giulia":"Sedan","Stelvio":"SUV","Tonale":"SUV"},"Aprilia":{"RS 660":"Sport Bike","RSV4":"Sport Bike","Tuareg 660":"Adventure Bike","Tuono":"Sport Bike"},"Audi":{"A3":"Sedan","A4":"Sedan","A5":"Coupe","A6":"Sedan","A7":"Sedan","A8":"Sedan","e-tron":"SUV","e-tron GT":"Sedan","Q3":"SUV","Q4 e-tron":"SUV","Q5":"SUV","Q7":"SUV","Q8":"SUV","R8":"Sports Car","RS 3":"Sedan","RS 5":"Coupe","RS 6":"Wagon","RS 7":"Sedan","S3":"Sedan","S4":"Sedan","S5":"Coupe","TT":"Coupe"},"BMW":{"2 Series":"Coupe","3 Series":"Sedan","4 Series":"Coupe","5 Series":"Sedan","7 Series":"Sedan","8 Series":"Coupe","i4":"Sedan","i7":"Sedan","iX":"SUV","M2":"Coupe","M3":"Sedan","M4":"Coupe","M5":"Sedan","M8":"Coupe","R 1250 GS":"Adventure Bike","S 1000 RR":"Sport Bike","X1":"SUV","X2":"SUV","X3":"SUV","X4":"SUV","X5":"SUV","X6":"SUV","X7":"SUV","Z4":"Convertible"},"Buell":{"Firebolt":"Sport Bike","Lightning":"Standard Motorcycle","Ulysses":"Adventure Bike"},"Buick":{"Cascada":"Convertible","Century":"Sedan","Enclave":"SUV","Encore":"SUV","Encore GX":"SUV","Envision":"SUV","LaCrosse":"Sedan","LeSabre":"Sedan","Lucerne":"Sedan","Park Avenue":"Sedan","Rainier":"SUV","Regal":"Sedan","Rendezvous":"SUV","Verano":"Sedan"},"Cadillac":{"ATS":"Sedan","Celestiq":"Sedan","CT4":"Sedan","CT5":"Sedan","CT6":"Sedan","CTS":"Sedan","DeVille":"Sedan","DTS":"Sedan","Escalade":"SUV","Lyriq":"SUV","Seville":"Sedan","STS":"Sedan","XLR":"Convertible","XT4":"SUV","XT5":"SUV","XT6":"SUV"},"Can-Am":{"Defender":"UTV/Side-by-Side","Maverick":"UTV/Side-by-Side","Ryker":"Three-Wheeled Motorcycle","Spyder":"Three-Wheeled Motorcycle"},"Chevrolet":{"Astro":"Minivan","Avalanche":"Pickup Truck","Aveo":"Sedan","Beretta":"Coupe","Blazer":"SUV","Blazer EV":"SUV","Bolt EUV":"SUV","Bolt EV":"Hatchback","Camaro":"Coupe","Caprice":"Sedan","Captiva Sport":"SUV","Cavalier":"Sedan","Celebrity":"Sedan","Chevelle":"Coupe","Chevy II / Nova":"Sedan","City Express":"Cargo Van","Cobalt":"Sedan","Colorado":"Pickup Truck","Corsica":"Sedan","Corvette":"Sports Car","Cruze":"Sedan","El Camino":"Pickup Truck","Equinox":"SUV","Equinox EV":"SUV","Express":"Cargo Van","HHR":"Wagon","Impala":"Sedan","Low Cab Forward":"Commercial Truck","Lumina":"Sedan","Malibu":"Sedan","Metro":"Hatchback","Monte Carlo":"Coupe","Prizm":"Sedan","S-10":"Pickup Truck","Silverado 1500":"Pickup Truck","Silverado 2500HD":"Pickup Truck","Silverado 3500HD":"Pickup Truck","Silverado 4500HD":"Commercial Truck","Silverado 5500HD":"Commercial Truck","Silverado 6500HD":"Commercial Truck","Silverado EV":"Pickup Truck","Sonic":"Sedan","Spark":"Hatchback","SSR":"Pickup Truck","Suburban":"SUV","Tahoe":"SUV","Tracker":"SUV","TrailBlazer":"SUV","Traverse":"SUV","Trax":"SUV","Uplander":"Minivan","Venture":"Minivan","Volt":"Sedan"},"Chrysler":{"200":"Sedan","300":"Sedan","Aspen":"SUV","Concorde":"Sedan","Crossfire":"Coupe","Grand Voyager":"Minivan","Imperial":"Sedan","LHS":"Sedan","New Yorker":"Sedan","Pacifica":"Minivan","PT Cruiser":"Wagon","Sebring":"Sedan","Town & Country":"Minivan","Voyager":"Minivan"},"Dodge":{"Attitude":"Sedan","Avenger":"Sedan","Caliber":"Hatchback","Caravan":"Minivan","Challenger":"Coupe","Challenger SRT Demon / 170":"Coupe","Challenger SRT Hellcat":"Coupe","Charger":"Sedan","Charger Daytona":"Sedan","Charger SRT Hellcat":"Sedan","Dakota":"Pickup Truck","Dart":"Sedan","Durango":"SUV","Durango SRT / Hellcat":"SUV","Grand Caravan":"Minivan","Hornet":"SUV","Intrepid":"Sedan","Journey":"SUV","Magnum":"Wagon","Neon / SRT-4":"Sedan","Nitro":"SUV","Ram Van / B-series":"Cargo Van","Spirit":"Sedan","Stealth":"Coupe","Stratus":"Sedan","Viper":"Sports Car"},"Ducati":{"Diavel":"Cruiser","Hypermotard":"Standard Motorcycle","Monster":"Standard Motorcycle","Multistrada":"Adventure Bike","Panigale":"Sport Bike","Scrambler":"Standard Motorcycle","Streetfighter":"Standard Motorcycle"},"Fiat":{"124 Spider":"Convertible","500":"Hatchback","500L":"Wagon","500X":"SUV"},"Ford":{"Aerostar":"Minivan","Aspire":"Hatchback","Bronco":"SUV","Bronco Sport":"SUV","C-Max":"Wagon","Contour":"Sedan","Crown Victoria":"Sedan","E-Series":"Cargo Van","E-Transit":"Cargo Van","EcoSport":"SUV","Edge":"SUV","Escape":"SUV","Escort":"Sedan","Excursion":"SUV","Expedition":"SUV","Explorer":"SUV","F-150":"Pickup Truck","F-150 Lightning":"Pickup Truck","F-250 Super Duty":"Pickup Truck","F-350 Super Duty":"Pickup Truck","F-450 Super Duty":"Pickup Truck","F-550 Super Duty":"Commercial Truck","F-650":"Commercial Truck","F-750":"Commercial Truck","Festiva":"Hatchback","Fiesta":"Hatchback","Five Hundred":"Sedan","Flex":"SUV","Focus":"Sedan","Freestar":"Minivan","Freestyle":"SUV","Fusion":"Sedan","GT":"Sports Car","Maverick":"Pickup Truck","Mustang":"Coupe","Mustang Mach-E":"SUV","Probe":"Coupe","Ranger":"Pickup Truck","Taurus":"Sedan","Taurus X":"SUV","Thunderbird":"Convertible","Transit":"Cargo Van","Transit Connect":"Cargo Van","Windstar":"Minivan"},"Freightliner":{"108SD":"Commercial Truck","114SD":"Commercial Truck","122SD":"Commercial Truck","Cascadia":"Commercial Truck","Columbia":"Commercial Truck","Coronado":"Commercial Truck","EconicSD":"Commercial Truck","M2 106":"Commercial Truck","M2 112":"Commercial Truck"},"Genesis":{"G70":"Sedan","G80":"Sedan","G90":"Sedan","GV60":"SUV","GV70":"SUV","GV80":"SUV"},"GMC":{"Acadia":"SUV","Canyon":"Pickup Truck","Envoy":"SUV","Hummer EV":"Pickup Truck","Jimmy":"SUV","Safari":"Minivan","Savana":"Cargo Van","Sierra 1500":"Pickup Truck","Sierra 2500HD":"Pickup Truck","Sierra 3500HD":"Pickup Truck","Sierra 4500HD":"Commercial Truck","Sierra 5500HD":"Commercial Truck","Sierra 6500HD":"Commercial Truck","Sonoma":"Pickup Truck","Syclone":"Pickup Truck","Terrain":"SUV","TopKick":"Commercial Truck","Typhoon":"SUV","Yukon":"SUV","Yukon XL":"SUV"},"Harley-Davidson":{"CVO":"Touring Bike","LiveWire":"Standard Motorcycle","Pan America":"Adventure Bike","Road Glide":"Touring Bike","Softail":"Cruiser","Sportster":"Cruiser","Street Glide":"Touring Bike","Trike":"Three-Wheeled Motorcycle"},"Hino":{"155":"Commercial Truck","195":"Commercial Truck","238":"Commercial Truck","258":"Commercial Truck","268":"Commercial Truck","338":"Commercial Truck","L Series":"Commercial Truck","M Series":"Commercial Truck","XL Series":"Commercial Truck"},"Honda":{"Accord":"Sedan","Accord Hybrid":"Sedan","Africa Twin":"Adventure Bike","CBR Series":"Sport Bike","Civic":"Sedan","Civic Si":"Sedan","Civic Type R":"Hatchback","Clarity":"Sedan","CR-V":"SUV","CR-V Hybrid":"SUV","CR-Z":"Hatchback","CRF Series":"Dual-Sport","CRX":"Hatchback","Del Sol":"Convertible","Element":"SUV","Fit":"Hatchback","Gold Wing":"Touring Bike","Grom":"Standard Motorcycle","HR-V":"SUV","Insight":"Sedan","Odyssey":"Minivan","Passport":"SUV","Pilot":"SUV","Prelude":"Coupe","Prologue":"SUV","Ridgeline":"Pickup Truck","S2000":"Convertible","Shadow":"Cruiser"},"Hummer":{"H1":"SUV","H2":"SUV","H3":"SUV"},"Husqvarna":{"FC 450":"Motocross/Off-road","Norden 901":"Adventure Bike","Svartpilen":"Standard Motorcycle","Vitpilen":"Standard Motorcycle"},"Hyundai":{"Accent":"Sedan","Azera":"Sedan","Elantra":"Sedan","Entourage":"Minivan","Equus":"Sedan","Genesis":"Sedan","Genesis Coupe":"Coupe","Ioniq 5":"SUV","Ioniq 6":"Sedan","Kona":"SUV","Nexo":"SUV","Palisade":"SUV","Santa Cruz":"Pickup Truck","Santa Fe":"SUV","Sonata":"Sedan","Tiburon":"Coupe","Tucson":"SUV","Veloster":"Hatchback","Venue":"SUV","Veracruz":"SUV"},"Indian":{"Challenger":"Touring Bike","Chieftain":"Touring Bike","Chief":"Cruiser","FTR":"Standard Motorcycle","Scout":"Cruiser","Springfield":"Touring Bike"},"Infiniti":{"EX":"SUV","FX":"SUV","G20":"Sedan","G35":"Sedan","G37":"Coupe","I30":"Sedan","I35":"Sedan","JX":"SUV","M":"Sedan","Q40":"Sedan","Q50":"Sedan","Q60":"Coupe","Q70":"Sedan","QX30":"SUV","QX4":"SUV","QX50":"SUV","QX55":"SUV","QX60":"SUV","QX70":"SUV","QX80":"SUV"},"International":{"CV Series":"Commercial Truck","DuraStar":"Commercial Truck","HV Series":"Commercial Truck","HX Series":"Commercial Truck","LoneStar":"Commercial Truck","LT Series":"Commercial Truck","MV Series":"Commercial Truck","ProStar":"Commercial Truck","RH Series":"Commercial Truck","WorkStar":"Commercial Truck"},"Isuzu":{"Ascender":"SUV","Axiom":"SUV","D-Max":"Pickup Truck","F-Series":"Commercial Truck","Hombre":"Pickup Truck","i-Series":"Pickup Truck","N-Series":"Commercial Truck","Oasis":"Minivan","Rodeo":"SUV","Stylus":"Sedan","Trooper":"SUV"},"Jaguar":{"E-PACE":"SUV","F-PACE":"SUV","F-TYPE":"Sports Car","I-PACE":"SUV","S-Type":"Sedan","X-Type":"Sedan","XE":"Sedan","XF":"Sedan","XJ":"Sedan","XK":"Coupe"},"Jeep":{"Cherokee":"SUV","Commander":"SUV","Compass":"SUV","Gladiator":"Pickup Truck","Grand Cherokee":"SUV","Grand Wagoneer":"SUV","Liberty":"SUV","Patriot":"SUV","Renegade":"SUV","Wagoneer":"SUV","Wrangler":"SUV","Wrangler 4xe":"SUV"},"Kawasaki":{"Concours":"Touring Bike","KLR650":"Dual-Sport","Ninja":"Sport Bike","Versys":"Adventure Bike","Vulcan":"Cruiser","Z Series":"Standard Motorcycle"},"Kenworth":{"C500":"Commercial Truck","K270":"Commercial Truck","K370":"Commercial Truck","T280":"Commercial Truck","T380":"Commercial Truck","T480":"Commercial Truck","T680":"Commercial Truck","T800":"Commercial Truck","T880":"Commercial Truck","W900":"Commercial Truck","W990":"Commercial Truck"},"Kia":{"Amanti":"Sedan","Borrego":"SUV","Cadenza":"Sedan","Carnival":"Minivan","EV6":"SUV","EV9":"SUV","Forte":"Sedan","K5":"Sedan","K900":"Sedan","Niro":"SUV","Optima":"Sedan","Rio":"Sedan","Rondo":"Wagon","Sedona":"Minivan","Seltos":"SUV","Sephia":"Sedan","Sorento":"SUV","Soul":"Wagon","Spectra":"Sedan","Sportage":"SUV","Stinger":"Sedan","Telluride":"SUV"},"KTM":{"Adventure Series":"Adventure Bike","Duke Series":"Standard Motorcycle","EXC-F Series":"Dual-Sport","RC Series":"Sport Bike"},"Land Rover":{"Defender":"SUV","Discovery":"SUV","Discovery Sport":"SUV","Freelander":"SUV","LR2":"SUV","LR3":"SUV","LR4":"SUV","Range Rover":"SUV","Range Rover Evoque":"SUV","Range Rover Sport":"SUV","Range Rover Velar":"SUV"},"Lexus":{"CT":"Hatchback","ES":"Sedan","GS":"Sedan","GX":"SUV","HS":"Sedan","IS":"Sedan","LC":"Coupe","LFA":"Sports Car","LS":"Sedan","LX":"SUV","NX":"SUV","RC":"Coupe","RX":"SUV","RZ":"SUV","SC":"Convertible","TX":"SUV"},"Lincoln":{"Aviator":"SUV","Blackwood":"Pickup Truck","Continental":"Sedan","Corsair":"SUV","LS":"Sedan","Mark LT":"Pickup Truck","Mark VIII":"Coupe","MKS":"Sedan","MKT":"SUV","MKX":"SUV","MKZ":"Sedan","Nautilus":"SUV","Navigator":"SUV","Town Car":"Sedan","Zephyr":"Sedan"},"Lucid":{"Air":"Sedan"},"Mack":{"Anthem":"Commercial Truck","Granite":"Commercial Truck","LR":"Commercial Truck","MD Series":"Commercial Truck","Pinnacle":"Commercial Truck","TerraPro":"Commercial Truck"},"Maserati":{"Ghibli":"Sedan","GranTurismo":"Coupe","Grecale":"SUV","Levante":"SUV","MC20":"Sports Car","Quattroporte":"Sedan"},"Mazda":{"2":"Hatchback","3":"Sedan","5":"Minivan","6":"Sedan","626":"Sedan","CX-3":"SUV","CX-30":"SUV","CX-5":"SUV","CX-50":"SUV","CX-7":"SUV","CX-9":"SUV","CX-90":"SUV","Mazda3":"Sedan","Mazda5":"Minivan","Mazda6":"Sedan","Millenia":"Sedan","MPV":"Minivan","MX-3":"Coupe","MX-5 Miata":"Convertible","MX-6":"Coupe","Protege":"Sedan","RX-7":"Sports Car","RX-8":"Coupe","Tribute":"SUV"},"Mercedes-Benz":{"A-Class":"Sedan","AMG GT":"Sports Car","B-Class":"Hatchback","C-Class":"Sedan","CL-Class":"Coupe","CLA":"Sedan","CLK-Class":"Coupe","CLS":"Sedan","E-Class":"Sedan","eSprinter":"Cargo Van","EQB":"SUV","EQE":"Sedan","EQS":"Sedan","G-Class":"SUV","GL-Class":"SUV","GLA":"SUV","GLB":"SUV","GLC":"SUV","GLE":"SUV","GLK-Class":"SUV","GLS":"SUV","M-Class":"SUV","Metris":"Cargo Van","R-Class":"Minivan","S-Class":"Sedan","SL-Class":"Convertible","SLK-Class":"Convertible","Sprinter":"Cargo Van"},"Mercury":{"Capri":"Convertible","Cougar":"Coupe","Grand Marquis":"Sedan","Marauder":"Sedan","Mariner":"SUV","Milan":"Sedan","Montego":"Sedan","Mountaineer":"SUV","Mystique":"Sedan","Sable":"Sedan","Topaz":"Sedan","Tracer":"Sedan","Villager":"Minivan"},"Mini":{"Clubman":"Wagon","Convertible":"Convertible","Countryman":"SUV","Hardtop":"Hatchback"},"Mitsubishi":{"3000GT":"Sports Car","Diamante":"Sedan","Eclipse":"Coupe","Eclipse Cross":"SUV","Endeavor":"SUV","Galant":"Sedan","i-MiEV":"Hatchback","Lancer":"Sedan","Mirage":"Hatchback","Mirage G4":"Sedan","Montero":"SUV","Montero Sport":"SUV","Outlander":"SUV","Outlander PHEV":"SUV","Outlander Sport":"SUV","Raider":"Pickup Truck"},"Mitsubishi Fuso":{"Canter":"Commercial Truck","eCanter":"Commercial Truck","FA/FI Series":"Commercial Truck","FE/FG Series":"Commercial Truck"},"Moto Guzzi":{"V100 Mandello":"Touring Bike","V7":"Standard Motorcycle","V85 TT":"Adventure Bike","V9":"Cruiser"},"MV Agusta":{"Brutale":"Standard Motorcycle","Dragster":"Standard Motorcycle","F3":"Sport Bike","Turismo Veloce":"Touring Bike"},"Nissan":{"200SX":"Coupe","240SX":"Coupe","300ZX":"Sports Car","350Z":"Sports Car","370Z":"Sports Car","Altima":"Sedan","Ariya":"SUV","Armada":"SUV","Cube":"Wagon","Frontier":"Pickup Truck","GT-R":"Sports Car","Juke":"SUV","Kicks":"SUV","Leaf":"Hatchback","Maxima":"Sedan","Murano":"SUV","NV":"Cargo Van","NV200":"Cargo Van","Pathfinder":"SUV","Pulsar":"Hatchback","Quest":"Minivan","Rogue":"SUV","Sentra":"Sedan","Stanza":"Sedan","Titan":"Pickup Truck","Titan XD":"Pickup Truck","Versa":"Sedan","Xterra":"SUV","Z":"Sports Car"},"Norton":{"Commando 961":"Standard Motorcycle","V4SV":"Sport Bike"},"Peterbilt":{"220":"Commercial Truck","325":"Commercial Truck","330":"Commercial Truck","337":"Commercial Truck","348":"Commercial Truck","365":"Commercial Truck","367":"Commercial Truck","389":"Commercial Truck","520":"Commercial Truck","536":"Commercial Truck","537":"Commercial Truck","548":"Commercial Truck","567":"Commercial Truck","579":"Commercial Truck","589":"Commercial Truck"},"Piaggio":{"Beverly":"Scooter","Liberty":"Scooter","MP3":"Scooter"},"Polestar":{"Polestar 1":"Coupe","Polestar 2":"Sedan","Polestar 3":"SUV"},"Pontiac":{"6000":"Sedan","Aztek":"SUV","Bonneville":"Sedan","Fiero":"Sports Car","Firebird":"Coupe","G3":"Hatchback","G5":"Coupe","G6":"Sedan","G8":"Sedan","Grand Am":"Sedan","Grand Prix":"Sedan","GTO":"Coupe","LeMans":"Hatchback","Montana":"Minivan","Solstice":"Convertible","Sunbird":"Sedan","Sunfire":"Sedan","Torrent":"SUV","Trans Sport":"Minivan","Vibe":"Wagon"},"Porsche":{"718 Boxster":"Convertible","718 Cayman":"Coupe","911":"Sports Car","928":"Sports Car","944":"Sports Car","Carrera GT":"Sports Car","Cayenne":"SUV","Macan":"SUV","Panamera":"Sedan","Taycan":"Sedan"},"Ram":{"1500":"Pickup Truck","2500":"Pickup Truck","3500":"Pickup Truck","4500":"Commercial Truck","5500":"Commercial Truck","Chassis Cab":"Commercial Truck","ProMaster":"Cargo Van","ProMaster City":"Cargo Van"},"Rivian":{"R1S":"SUV","R1T":"Pickup Truck"},"Royal Enfield":{"Classic 350":"Standard Motorcycle","Continental GT":"Standard Motorcycle","Himalayan":"Adventure Bike","Interceptor 650":"Standard Motorcycle"},"Saab":{"9-2X":"Wagon","9-3":"Sedan","9-4X":"SUV","9-5":"Sedan","9-7X":"SUV","900":"Sedan","9000":"Sedan"},"Saturn":{"Astra":"Hatchback","Aura":"Sedan","Ion":"Sedan","L-Series":"Sedan","Outlook":"SUV","Relay":"Minivan","S-Series":"Sedan","Sky":"Convertible","Vue":"SUV"},"Scion":{"FR-S":"Coupe","iA":"Sedan","iM":"Hatchback","iQ":"Hatchback","tC":"Coupe","xA":"Hatchback","xB":"Wagon","xD":"Hatchback"},"Subaru":{"Ascent":"SUV","B9 Tribeca":"SUV","Baja":"Pickup Truck","BRZ":"Coupe","Crosstrek":"SUV","Forester":"SUV","Impreza":"Sedan","Justy":"Hatchback","Legacy":"Sedan","Loyale":"Wagon","Outback":"Wagon","Solterra":"SUV","SVX":"Coupe","Tribeca":"SUV","WRX":"Sedan","XT":"Coupe"},"Suzuki":{"Aerio":"Sedan","DR-Z400S":"Dual-Sport","Equator":"Pickup Truck","Esteem":"Sedan","Forenza":"Sedan","Grand Vitara":"SUV","GSX-R Series":"Sport Bike","Hayabusa":"Sport Bike","Katana":"Sport Bike","Kizashi":"Sedan","Reno":"Hatchback","Samurai":"SUV","Sidekick":"SUV","SV650":"Standard Motorcycle","Swift":"Hatchback","SX4":"Hatchback","V-Strom":"Adventure Bike","Verona":"Sedan","Vitara":"SUV","X-90":"SUV","XL7":"SUV"},"Tesla":{"Cybertruck":"Pickup Truck","Model 3":"Sedan","Model S":"Sedan","Model X":"SUV","Model Y":"SUV","Roadster":"Sports Car","Semi":"Commercial Truck"},"Toyota":{"4Runner":"SUV","86":"Coupe","Avalon":"Sedan","bZ4X":"SUV","C-HR":"SUV","Camry":"Sedan","Celica":"Coupe","Corolla":"Sedan","Corolla Cross":"SUV","Corolla Hatchback":"Hatchback","Corolla iM":"Hatchback","Cressida":"Sedan","Crown":"Sedan","Echo":"Sedan","FJ Cruiser":"SUV","GR Corolla":"Hatchback","GR Supra":"Sports Car","GR86":"Coupe","Grand Highlander":"SUV","Highlander":"SUV","Land Cruiser":"SUV","Matrix":"Wagon","Mirai":"Sedan","MR2 / MR2 Spyder":"Sports Car","Paseo":"Coupe","Previa":"Minivan","Prius":"Hatchback","Prius Prime":"Hatchback","RAV4":"SUV","RAV4 Prime":"SUV","Sequoia":"SUV","Sienna":"Minivan","Solara":"Coupe","Supra":"Sports Car","T100":"Pickup Truck","Tacoma":"Pickup Truck","Tercel":"Sedan","Tundra":"Pickup Truck","Venza":"SUV","Yaris":"Hatchback"},"Triumph":{"Bonneville":"Standard Motorcycle","Rocket 3":"Cruiser","Scrambler":"Standard Motorcycle","Speed Triple":"Standard Motorcycle","Street Triple":"Standard Motorcycle","Tiger":"Adventure Bike","Trident":"Standard Motorcycle"},"Vespa":{"GTS":"Scooter","Primavera":"Scooter","Sprint":"Scooter"},"Volkswagen":{"Arteon":"Sedan","Atlas":"SUV","Atlas Cross Sport":"SUV","Beetle":"Hatchback","Cabrio":"Convertible","CC":"Sedan","Corrado":"Coupe","Eos":"Convertible","Fox":"Sedan","Golf":"Hatchback","Golf R":"Hatchback","GTI":"Hatchback","ID.4":"SUV","Jetta":"Sedan","Jetta GLI":"Sedan","New Beetle":"Hatchback","Passat":"Sedan","Phaeton":"Sedan","Rabbit":"Hatchback","Routan":"Minivan","Taos":"SUV","Tiguan":"SUV","Touareg":"SUV","Vanagon":"Minivan"},"Volvo":{"C30":"Hatchback","C40 Recharge":"SUV","C70":"Convertible","S40":"Sedan","S60":"Sedan","S70":"Sedan","S80":"Sedan","S90":"Sedan","V40":"Wagon","V50":"Wagon","V60":"Wagon","V70":"Wagon","V90":"Wagon","VHD":"Commercial Truck","VNL":"Commercial Truck","VNR":"Commercial Truck","XC40":"SUV","XC60":"SUV","XC70":"Wagon","XC90":"SUV"},"Yamaha":{"Bolt":"Cruiser","MT Series":"Standard Motorcycle","Super Ténéré":"Adventure Bike","Tracer 9":"Touring Bike","TW200":"Dual-Sport","VMAX":"Cruiser","V Star":"Cruiser","XSR Series":"Standard Motorcycle","YZF-R Series":"Sport Bike","Zuma":"Scooter"},"Zero Motorcycles":{"DSR/X":"Adventure Bike","FXE":"Standard Motorcycle","SR/F":"Standard Motorcycle","SR/S":"Sport Bike"},"Other":{"Other":"Other"}};
 
+const isElectric = (make, model) => {
+    const electricMakes = ['Tesla', 'Rivian', 'Lucid', 'Polestar', 'Zero Motorcycles'];
+    if (electricMakes.includes(make)) return true;
+
+    const electricModelsByMake = {
+        'Audi': ['e-tron', 'e-tron GT', 'Q4 e-tron'],
+        'BMW': ['i4', 'i7', 'iX'],
+        'Cadillac': ['Celestiq', 'Lyriq'],
+        'Chevrolet': ['Blazer EV', 'Bolt EUV', 'Bolt EV', 'Equinox EV', 'Silverado EV'],
+        'Ford': ['E-Transit', 'F-150 Lightning', 'Mustang Mach-E'],
+        'Genesis': ['GV60'],
+        'GMC': ['Hummer EV'],
+        'Honda': ['Prologue'],
+        'Hyundai': ['Ioniq 5', 'Ioniq 6', 'Kona'],
+        'Jaguar': ['I-PACE'],
+        'Jeep': ['Wrangler 4xe'],
+        'Kia': ['EV6', 'EV9', 'Niro'],
+        'Lexus': ['RZ'],
+        'Mercedes-Benz': ['eSprinter', 'EQB', 'EQE', 'EQS'],
+        'Mini': ['Hardtop'],
+        'Mitsubishi': ['i-MiEV'],
+        'Mitsubishi Fuso': ['eCanter'],
+        'Nissan': ['Ariya', 'Leaf'],
+        'Porsche': ['Taycan'],
+        'Subaru': ['Solterra'],
+        'Toyota': ['bZ4X', 'Mirai'],
+        'Volkswagen': ['ID.4'],
+        'Volvo': ['C40 Recharge', 'XC40']
+    };
+
+    return electricModelsByMake[make]?.includes(model) || false;
+};
+
 app.use(cors());
 app.use(express.json());
 app.use('/js', express.static(path.join(__dirname, 'js')));
@@ -644,66 +677,131 @@ app.post('/api/reviews', authenticateToken, async (req, res) => {
 
       res.status(201).json({ success: true, review_id: result.insertId });
 
+      // Post-review submission logic (badge awards, etc.)
       (async () => {
         try {
             const [userReviews] = await db.query('SELECT vehicle_make, vehicle_model FROM reviews WHERE user_id = ?', [user_id]);
             const totalReviewsCount = userReviews.length;
 
-            const reviewerBadgeChecks = [
-                { count: 5, id: '0356' },
-                { count: 10, id: '0357' },
-                { count: 50, id: '0358' },
-                { count: 100, id: '0359' },
-                { count: 500, id: '0360' },
-                { count: 1000, id: '0361' }
+            const awardBadge = async (badgeId) => {
+                const [result] = await db.query('INSERT IGNORE INTO user_badges (user_id, badge_id) VALUES (?, ?)', [user_id, badgeId]);
+                if (result.affectedRows > 0) {
+                    const [badgeRows] = await db.query('SELECT name FROM badges WHERE badge_id = ?', [badgeId]);
+                    if (badgeRows.length > 0) {
+                        const badgeName = badgeRows[0].name;
+                        const content = `You've earned the "${badgeName}" badge!`;
+                        await db.query(
+                            'INSERT INTO notifications (user_id, type, content, related_id) VALUES (?, ?, ?, ?)',
+                            [user_id, 'badge', content, badgeId]
+                        );
+                    }
+                }
+            };
+
+            // 1. General Reviewer Badges
+            const reviewerBadgeTiers = [
+                { count: 5, id: '0356' }, { count: 10, id: '0357' }, { count: 50, id: '0358' },
+                { count: 100, id: '0359' }, { count: 500, id: '0360' }, { count: 1000, id: '0361' }
+            ];
+            for (const tier of reviewerBadgeTiers) {
+                if (totalReviewsCount >= tier.count) await awardBadge(tier.id);
+            }
+
+            // 2. Vehicle Type Specific Badges
+            const vehicleTypeBadges = {
+                'Sedan': ['0100', '0101', '0102', '0103', '0104', '0105'],
+                'Adventure Bike': ['0106', '0107', '0108', '0109', '0110', '0111'],
+                'Cargo Van': ['0112', '0113', '0114', '0115', '0116', '0117'],
+                'Commercial Truck': ['0118', '0119', '0120', '0121', '0122', '0123'],
+                'Convertible': ['0124', '0125', '0126', '0127', '0128', '0129'],
+                'Coupe': ['0130', '0131', '0132', '0133', '0134', '0135'],
+                'Cruiser': ['0136', '0137', '0138', '0139', '0140', '0141'],
+                'Dual-Sport': ['0142', '0143', '0144', '0145', '0146', '0147'],
+                'Hatchback': ['0178', '0179', '0180', '0181', '0182', '0183'],
+                'Minivan': ['0184', '0185', '0186', '0187', '0188', '0189'],
+                'Motocross/Off-road': ['0190', '0191', '0192', '0193', '0194', '0195'],
+                'Other': ['0196', '0197', '0198', '0199', '0200', '0201'],
+                'Pickup Truck': ['0202', '0203', '0204', '0205', '0206', '0207'],
+                'SUV': ['0208', '0209', '0210', '0211', '0212', '0213'],
+                'Scooter': ['0214', '0215', '0216', '0217', '0218', '0219'],
+                'Sport Bike': ['0220', '0221', '0222', '0223', '0224', '0225'],
+                'Sports Car': ['0226', '0227', '0228', '0229', '0230', '0231'],
+                'Standard Motorcycle': ['0232', '0233', '0234', '0235', '0236', '0237'],
+                'Three-Wheeled Motorcycle': ['0238', '0239', '0240', '0241', '0242', '0243'],
+                'Touring Bike': ['0244', '0245', '0246', '0247', '0248', '0249'],
+                'UTV/Side-by-Side': ['0250', '0251', '0252', '0253', '0254', '0255'],
+                'Wagon': ['0256', '0257', '0258', '0259', '0260', '0261'],
+            };
+            const badgeTiers = [
+                { count: 5, index: 0 }, { count: 10, index: 1 }, { count: 50, index: 2 },
+                { count: 100, index: 3 }, { count: 500, index: 4 }, { count: 1000, index: 5 }
             ];
 
-            for (const check of reviewerBadgeChecks) {
-                if (totalReviewsCount >= check.count) {
-                    const [result] = await db.query('INSERT IGNORE INTO user_badges (user_id, badge_id) VALUES (?, ?)', [user_id, check.id]);
-                    if (result.affectedRows > 0) {
-                        const [badgeRows] = await db.query('SELECT name FROM badges WHERE badge_id = ?', [check.id]);
-                        if (badgeRows.length > 0) {
-                            const badgeName = badgeRows[0].name;
-                            const content = `You've earned the "${badgeName}" badge!`;
-                            await db.query(
-                                'INSERT INTO notifications (user_id, type, content, related_id) VALUES (?, ?, ?, ?)',
-                                [user_id, 'badge', content, check.id]
-                            );
+            const countsByType = userReviews.reduce((acc, review) => {
+                const type = vehicleSubtype[review.vehicle_make]?.[review.vehicle_model];
+                if (type) acc[type] = (acc[type] || 0) + 1;
+                return acc;
+            }, {});
+
+            for (const type in countsByType) {
+                if (vehicleTypeBadges[type]) {
+                    const badgesForType = vehicleTypeBadges[type];
+                    for (const tier of badgeTiers) {
+                        if (countsByType[type] >= tier.count) {
+                            await awardBadge(badgesForType[tier.index]);
                         }
                     }
                 }
             }
 
-            const sedanCount = userReviews.filter(review =>
-                vehicleSubtype[review.vehicle_make]?.[review.vehicle_model] === 'Sedan'
-            ).length;
+            // 3. Electric Vehicle Badges
+            const evBadgeGroups = {
+                'EV Car': {
+                    types: ['Sedan', 'Coupe', 'Sports Car', 'Wagon', 'Hatchback', 'Convertible', 'Other'],
+                    badges: ['0148', '0149', '0150', '0151', '0152', '0153']
+                },
+                'EV Moto': {
+                    types: ['Sport Bike', 'Adventure Bike', 'Standard Motorcycle', 'Cruiser', 'Dual-Sport', 'Touring Bike', 'Three-Wheeled Motorcycle', 'Scooter'],
+                    badges: ['0154', '0155', '0156', '0157', '0158', '0159']
+                },
+                'EV SUV': {
+                    types: ['SUV'],
+                    badges: ['0160', '0161', '0162', '0163', '0164', '0165']
+                },
+                'EV Truck': {
+                    types: ['Pickup Truck', 'Commercial Truck'],
+                    badges: ['0166', '0167', '0168', '0169', '0170', '0171']
+                },
+                'EV Van': {
+                    types: ['Cargo Van', 'Minivan'],
+                    badges: ['0172', '0173', '0174', '0175', '0176', '0177']
+                }
+            };
 
-            const sedanBadgeChecks = [
-                { count: 5, id: '0100' },
-                { count: 10, id: '0101' },
-                { count: 50, id: '0102' },
-                { count: 100, id: '0103' },
-                { count: 500, id: '0104' },
-                { count: 1000, id: '0105' }
-            ];
-
-            for (const check of sedanBadgeChecks) {
-                if (sedanCount >= check.count) {
-                    const [result] = await db.query('INSERT IGNORE INTO user_badges (user_id, badge_id) VALUES (?, ?)', [user_id, check.id]);
-                    if (result.affectedRows > 0) {
-                        const [badgeRows] = await db.query('SELECT name FROM badges WHERE badge_id = ?', [check.id]);
-                        if (badgeRows.length > 0) {
-                            const badgeName = badgeRows[0].name;
-                            const content = `You've earned the "${badgeName}" badge!`;
-                            await db.query(
-                                'INSERT INTO notifications (user_id, type, content, related_id) VALUES (?, ?, ?, ?)',
-                                [user_id, 'badge', content, check.id]
-                            );
+            const evCounts = { 'EV Car': 0, 'EV Moto': 0, 'EV SUV': 0, 'EV Truck': 0, 'EV Van': 0 };
+            for (const review of userReviews) {
+                if (isElectric(review.vehicle_make, review.vehicle_model)) {
+                    const type = vehicleSubtype[review.vehicle_make]?.[review.vehicle_model];
+                    if (type) {
+                        for (const evGroup in evBadgeGroups) {
+                            if (evBadgeGroups[evGroup].types.includes(type)) {
+                                evCounts[evGroup]++;
+                            }
                         }
                     }
                 }
             }
+
+            for (const evGroup in evCounts) {
+                const groupCount = evCounts[evGroup];
+                const badgesForGroup = evBadgeGroups[evGroup].badges;
+                for (const tier of badgeTiers) {
+                    if (groupCount >= tier.count) {
+                        await awardBadge(badgesForGroup[tier.index]);
+                    }
+                }
+            }
+
         } catch (badgeError) {
             console.error('❌ Badge awarding failed after review submission:', badgeError);
         }


### PR DESCRIPTION
This commit introduces a dynamic and scalable badge system for various vehicle types, expanding beyond the original "Sedan" badges.

Key changes:
- Refactored the badge-awarding logic in `server.js` to be generic, replacing the hardcoded sedan implementation with a data-driven approach.
- Introduced a new data structure `vehicleTypeBadges` to map 22 vehicle subtypes (e.g., SUV, Coupe, Sport Bike) to their corresponding badge series.
- Implemented logic for new Electric Vehicle (EV) badges for categories like "EV Car", "EV SUV", and "EV Truck".
- Added a helper function `isElectric(make, model)` to identify EVs based on a comprehensive list compiled from the project's vehicle data, allowing your reviews to count towards both primary type and EV type badges.
- All new badge types listed in the issue are now supported and will be awarded to you upon meeting the review count criteria (5, 10, 50, 100, 500, 1000).