### PR TITLE
Implement secret badges feature

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -662,7 +662,7 @@ document.addEventListener('DOMContentLoaded', () => {
         await Promise.all([
             fetchData('/users', 'users'),
             fetchData('/admin/reviews', 'reviews'),
-            fetchData('/badges', 'badges'),
+            fetchData('/admin/badges', 'badges'),
             fetchData('/user_badges', 'userBadges'),
             fetchData('/review_votes', 'reviewVotes')
         ]);


### PR DESCRIPTION
This change introduces the concept of "secret badges" that are only visible to users who have earned them.

- **Backend:**
  - Adds a new `/api/admin/badges` endpoint to allow admins to see and award all badges, including secret ones.
  - Modifies `/api/badges` to only show non-secret badges publicly.
  - Updates user profile endpoints to include an `is_secret` flag for earned badges.

- **Frontend:**
  - Updates the badge display logic in `js/main.js` to hide unearned secret badges.
  - Modifies `js/admin.js` to use the new admin endpoint for fetching badges, allowing admins to award secret badges.