### PR TITLE
feat: Autofill incident state based on user location

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3196,8 +3196,24 @@ const reassignModalElements = () => {
     }
 
     addReviewBtn.addEventListener('click', () => {
-        if (authToken) reviewModal.classList.remove('hidden');
-        else authModal.classList.remove('hidden');
+        if (authToken) {
+            // Try to get location from native interface
+            if (window.Android && typeof window.Android.getUserLocation === 'function') {
+                const userState = window.Android.getUserLocation();
+                if (userState) {
+                    const incidentLocationSelect = document.getElementById('incident_location');
+                    if (incidentLocationSelect) {
+                        // Check if the state exists in the dropdown before setting it
+                        if ([...incidentLocationSelect.options].map(o => o.value).includes(userState)) {
+                            incidentLocationSelect.value = userState;
+                        }
+                    }
+                }
+            }
+            reviewModal.classList.remove('hidden');
+        } else {
+            authModal.classList.remove('hidden');
+        }
     });
     closeModalBtn.addEventListener('click', () => reviewModal.classList.add('hidden'));
 

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-const CACHE_NAME = 'platetraits-cache-v2';
-const API_CACHE_NAME = 'platetraits-api-cache-v2';
+const CACHE_NAME = 'platetraits-cache-v3';
+const API_CACHE_NAME = 'platetraits-api-cache-v3';
 const STATIC_ASSETS = [
     '/',
     '/home.html',


### PR DESCRIPTION
This commit introduces a feature to automatically fill the incident state in the review form based on the user's location when the app is running in an Android webview.

The changes include:
- Modifying the 'Add Review' button's event listener in `js/main.js` to check for a `window.Android.getUserLocation` function.
- If the function exists, it's called to retrieve the user's state, which is then used to pre-select the 'Incident State' dropdown.
- This implementation is safe for standard browsers as it only executes when the specific Android interface is present.
- The service worker cache version in `sw.js` has been updated to `v3` to ensure that the changes to `js/main.js` are correctly picked up by users.