### PR TITLE
feat: Add Play Store coming soon note

### DIFF
--- a/home.html
+++ b/home.html
@@ -365,6 +365,7 @@
                     </svg>
                     <span>Get the App</span>
                 </a>
+                <p class="text-xs text-tertiary text-center mt-1">Coming soon to the Play Store!</p>
             </div>
 
             <div class="p-4 border-t border-color space-y-4">
@@ -849,6 +850,7 @@
             <div>
                 <p class="font-bold text-lg">Get the PlateTraits App</p>
                 <p class="text-sm text-secondary">For a better experience, download our Android app.</p>
+                <p class="text-xs text-tertiary mt-1">Coming soon to the Play Store!</p>
             </div>
         </div>
         <div class="flex items-center">


### PR DESCRIPTION
Adds a small note to the download sections on the homepage to inform users that the PlateTraits app will be available on the Google Play Store soon.

The note is added to both the side menu's "Get the App" link and the download banner at the bottom of the page.