### PR TITLE
feat: Display app download count on admin dashboard

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -62,7 +62,7 @@
 
   <main class="mx-auto max-w-7xl p-4 sm:p-6 lg:p-8 space-y-6">
     <!-- Stats -->
-    <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+    <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4">
       <div class="stat-card panel rounded-xl p-4 bg-white dark:bg-gray-900">
         <div class="text-sm text-gray-500">Total Users</div>
         <div id="total-users" class="text-3xl font-semibold mt-1">—</div>
@@ -82,6 +82,10 @@
       <div class="stat-card panel rounded-xl p-4 bg-white dark:bg-gray-900">
         <div class="text-sm text-gray-500">Total Votes</div>
         <div id="total-votes" class="text-3xl font-semibold mt-1">—</div>
+      </div>
+      <div class="stat-card panel rounded-xl p-4 bg-white dark:bg-gray-900">
+        <div class="text-sm text-gray-500">App Downloads</div>
+        <div id="total-downloads" class="text-3xl font-semibold mt-1">—</div>
       </div>
     </section>
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1193,6 +1193,18 @@ app.get('/api/stats', async (req, res) => {
     }
 });
 
+// NEW: Endpoint to get app download stats for the admin dashboard
+app.get('/api/admin/stats/downloads', authenticateToken, requireAdmin, async (req, res) => {
+    try {
+        const [rows] = await db.query('SELECT count FROM apk_downloads WHERE id = 1');
+        const downloadCount = rows[0]?.count || 0;
+        res.json({ success: true, downloads: downloadCount });
+    } catch (err) {
+        console.error('❌ Failed to fetch app download stats for admin:', err);
+        res.status(500).json({ success: false, message: 'Database error while fetching app download stats.' });
+    }
+});
+
 // Endpoint to get all user_badges for the admin dashboard
 app.get('/api/user_badges', authenticateToken, requireAdmin, async (req, res) => {
     try {

--- a/js/admin.js
+++ b/js/admin.js
@@ -44,6 +44,7 @@ const vehicleSubtype = {"Acura":{"ILX":"Sedan","Integra":"Sedan","MDX":"SUV","NS
     badges: [],
     userBadges: [],
     reviewVotes: [],
+    downloads: 0,
     usernameMap: {},
     filters: {
       username: localStorage.getItem('filter_username') || '',
@@ -85,6 +86,7 @@ const vehicleSubtype = {"Acura":{"ILX":"Sedan","Integra":"Sedan","MDX":"SUV","NS
       totalBadges: byId('total-badges'),
       totalUserBadges: byId('total-user-badges'),
       totalVotes: byId('total-votes'),
+      totalDownloads: byId('total-downloads'),
     },
     // filter
     filterInput: byId('user-filter'),
@@ -311,12 +313,13 @@ const vehicleSubtype = {"Acura":{"ILX":"Sedan","Integra":"Sedan","MDX":"SUV","NS
     showLoadingRows(els.reviewsBody, 8);
     showLoadingRows(els.votesBody, 5);
 
-    const [users, reviews, badges, userBadges, reviewVotes] = await Promise.all([
+    const [users, reviews, badges, userBadges, reviewVotes, downloadsStats] = await Promise.all([
       fetchJSON(`${API_URL}/users`),
       fetchJSON(`${API_URL}/admin/reviews`),
       fetchJSON(`${API_URL}/admin/badges`),
       fetchJSON(`${API_URL}/user_badges`),
-      fetchJSON(`${API_URL}/review_votes`)
+      fetchJSON(`${API_URL}/review_votes`),
+      fetchJSON(`${API_URL}/admin/stats/downloads`)
     ]);
 
     state.users = users;
@@ -324,6 +327,7 @@ const vehicleSubtype = {"Acura":{"ILX":"Sedan","Integra":"Sedan","MDX":"SUV","NS
     state.badges = badges;
     state.userBadges = userBadges;
     state.reviewVotes = reviewVotes;
+    state.downloads = downloadsStats.downloads;
 
     state.usernameMap = {};
     for (const u of users) state.usernameMap[u.id] = u.username;
@@ -352,6 +356,7 @@ const vehicleSubtype = {"Acura":{"ILX":"Sedan","Integra":"Sedan","MDX":"SUV","NS
     els.stats.totalBadges.textContent = state.badges.length;
     els.stats.totalUserBadges.textContent = state.userBadges.length;
     els.stats.totalVotes.textContent = state.reviewVotes.length;
+    els.stats.totalDownloads.textContent = state.downloads;
   };
 
   const renderUsers = () => {


### PR DESCRIPTION
This commit introduces a new feature to the admin dashboard that displays the total number of APK downloads.

- Adds a new stat card to `admin.html` for 'App Downloads' and adjusts the grid layout.
- Updates `js/admin.js` to fetch and display the download count.
- Adds a new backend endpoint `/api/admin/stats/downloads` in `server.js` to provide the download count from the `apk_downloads` table.